### PR TITLE
Use the DEFAULT_CONFIG_FILE, this is the best fix for this issue.

### DIFF
--- a/sara_cmt/cmt_client/cmt_client/cmt.py
+++ b/sara_cmt/cmt_client/cmt_client/cmt.py
@@ -413,7 +413,7 @@ class Client:
         output_group.add_argument('--quiet', '-s', action='store_true', help='suppress output messages')
         parser.add_argument('--version', action='version', version='%(prog)s ' +str(cmt_version) )
 
-        parser.add_argument('--config-file', '-c', type=lambda x: is_valid_file(parser,x), default='/etc/cmt/cmt.conf', help='Which config file to use')
+        parser.add_argument('--config-file', '-c', type=lambda x: is_valid_file(parser,x), default=DEFAULT_CONFIG_FILE, help='Which config file to use')
 
         self.temp_args = args
 


### PR DESCRIPTION
Using DEFAULT_CONFIG_FILE as default value for the argument parser is the best solution after reading the code. When you specify with -c/--config a custom config file, the variable DEFAULT_CONFIG_FILE is not used.